### PR TITLE
Update background.js

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -11,7 +11,9 @@ chrome.action.onClicked.addListener(function (tab) {
  * @param {chrome.runtime.InstalledDetails} details Details about the installation.
  */
 chrome.runtime.onInstalled.addListener(function (details) {
-    chrome.tabs.create({ url: "https://github.com/YadaGiriReddy/Bulk-URL-Opener" });
+    if (details.reason === "install") {
+        chrome.tabs.create({ url: "https://github.com/YadaGiriReddy/Bulk-URL-Opener" });
+    }
 });
 
 /**


### PR DESCRIPTION
Add condition runtime.onInstalled listener to open page only on installation of extension
 

Since this event is also fired when the browser is updated for example.